### PR TITLE
Fix max raster size constant name in config file

### DIFF
--- a/no-face.toml
+++ b/no-face.toml
@@ -1,5 +1,5 @@
 api_root = "http://localhost:8080"
-max_size = 2048
+max_raster_size = 2048
 
 # Changes to this section are not reloaded by SIGHUP.
 [startup]


### PR DESCRIPTION
The `Config` struct contains field `max_raster_size` which is being set from the `no_face.toml` config file; however, the config file names the constant `max_size` instead of `max_raster_size`.

This has two consequences:

1. the `api_docs.html` page is unable to get a value for `max_size` and defaults to print "none" in the sentence "size determines the size of the image in pixels. It must be less than or equal to none."
2. The code within `main.rs` to check whether size limit has been exceeded defauls to the hardcoded 1024 even though a different limit has been provided in the config file.

I've resolved this using a very complex process of renaming the `max_size` constant in the `no_face.toml` file to `max_raster_size`.